### PR TITLE
Dockerfile and entrypoint revisions

### DIFF
--- a/site-build/Dockerfile
+++ b/site-build/Dockerfile
@@ -2,7 +2,6 @@
 # Dockerfile to build an image for a compiled and rendered rdfpub site
 FROM alpine:3.16.0
 COPY . /rdfpub
-WORKDIR /rdfpub
 
 # Set environment variables
 ENV \
@@ -64,7 +63,6 @@ mv /rdfpub/db/* $RDF4J_HOME/server/repositories/rdfpub/
 rm -rf /rdfpub/db/
 chown -R $RDF4J_USER:$JETTY_USER $RDF4J_HOME
 chmod ug+w -R $RDF4J_HOME
-#chmod a-w $RDF4J_HOME/server/repositories/rdfpub/*
 
 # Install and configure OpenResty
 wget -O- 'https://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' > /etc/apk/keys/admin@openresty.com-5ea678a6.rsa.pub

--- a/site-build/entrypoint.sh
+++ b/site-build/entrypoint.sh
@@ -10,8 +10,8 @@ OUTPUTDIR=$BASEDIR/output
 
 # Generate site
 mkdir -p output
-java -jar init.jar $INPUTDIR $OUTPUTDIR
-node render.min.js $OUTPUTDIR/layouts $OUTPUTDIR/resources
+java -jar $BASEDIR/init.jar $INPUTDIR $OUTPUTDIR
+node $BASEDIR/render.min.js $OUTPUTDIR/layouts $OUTPUTDIR/resources
 
 # Clean up unneeded layout files
 rm -rf $OUTPUTDIR/layouts


### PR DESCRIPTION
Dockerfiles are edited to remove all `WORKDIR` instructions and to use the 'exec' version of the `ENTRYPOINT` syntax. The site-build entrypoint.sh file was also modified to operate on absolute paths rather than paths relative to the working directory.

This is largely done as an attempt at compatibility with GitHub Actions, but also to reduce the number of image layers in the built Docker images.