### PR TITLE
Change tagging from IMAGE_TAG to Docker args, update readme accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ If you're totally new to rdfpub, check out [the rdfpub tutorial site](https://gi
 ```sh
 # Generate a Docker image of your site
 docker run                                     \
-  -e IMAGE_TAG=rdfpub/example                  \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /path/to/your/site/dir:/rdfpub/input:ro   \
-  ghcr.io/rdfpub/generator
+  ghcr.io/rdfpub/generator                     \
+  -t rdfpub/example
 
 # Run your site
 docker run -p 80:80 rdfpub/example

--- a/site-build/entrypoint.sh
+++ b/site-build/entrypoint.sh
@@ -27,4 +27,4 @@ find $OUTPUTDIR/resources \( \
   -exec brotli -9fkv {} \;
 
 # Build Docker image of site
-docker buildx build -f /rdfpub/Dockerfile -t $IMAGE_TAG $OUTPUTDIR
+docker buildx build -f /rdfpub/Dockerfile "$@" $OUTPUTDIR


### PR DESCRIPTION
Using the `IMAGE_TAG` environment variable is inflexible for some use cases. Tagging should instead be done via command-line arguments to `docker run` which are then passed into `docker buildx build`. This allows for other options to be passed into the build as well as making it easy to use multiple tags.

README.md is being updated to reflect this usage.