### PR TITLE
New render vars + helpers, misc. changes/fixes

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -37,4 +37,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }}
+          gh release create ${{ github.ref_name }} --generate-notes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Use this Dockerfile to build an rdfpub site
 #
 # Use like so:
-# docker build -t rdfpub/generator . && docker run rdfpub/generator \
-#   -e IMAGE_TAG=rdfpub/example \
+# docker build -t rdfpub/generator . && docker run \
 #   -v /var/run/docker.sock:/var/run/docker.sock \
-#   -v /path/to/site/dir:/rdfpub/input:ro
+#   -v /path/to/site/dir:/rdfpub/input:ro \
+#   rdfpub/generator \
+#   -t rdfpub/example
 
 # Download rdfpub
 FROM alpine:3.16.0 AS base
@@ -16,7 +17,7 @@ COPY . /rdfpub
 FROM maven:3.8.5-eclipse-temurin-17-alpine AS init
 COPY --from=base /rdfpub/init /rdfpub/init
 RUN cd /rdfpub/init \
- && mvn clean package
+ && mvn clean package -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 # Minify and package rendering process
 FROM node:18.3.0 AS render
@@ -34,7 +35,8 @@ RUN apk update \
  && apk add docker-cli-buildx \
  && apk add openjdk17-jre-headless \
  && apk add nodejs-current \
- && apk add brotli
+ && apk add brotli \
+ && apk add yq
 
 # Copy site generator tools
 COPY --from=base /rdfpub/site-build/Dockerfile /rdfpub/site-build/entrypoint.sh /rdfpub/

--- a/init/src/main/java/pub/rdf/builder/DatabaseBuilder.java
+++ b/init/src/main/java/pub/rdf/builder/DatabaseBuilder.java
@@ -104,11 +104,11 @@ public class DatabaseBuilder extends ConfigurableBuilder {
         connection.add(rdf.createStatement(rn, SD.NAME, config.getSPARQLEndpoint(), config.getSPARQLEndpoint()));
         connection.add(rdf.createStatement(rn, SD.GRAPH, gn, config.getSPARQLEndpoint()));
         connection.add(rdf.createStatement(gn, RDF.TYPE, SD.GRAPHCLASS, config.getSPARQLEndpoint()));
-        connection.add(rdf.createStatement(gn, VOID.TRIPLES, rdf.createLiteral(connection.size(config.getSPARQLEndpoint())), config.getSPARQLEndpoint()));
         connection.add(rdf.createStatement(rn, DCTerms.CREATED, rdf.createLiteral(new Date()), config.getSPARQLEndpoint()));
 
         connection.add(DATASET, SD.DEFAULTDATASET, dn, config.getSPARQLEndpoint());
         connection.add(dn, RDF.TYPE, SD.GRAPHCLASS, config.getSPARQLEndpoint());
+        connection.add(rdf.createStatement(gn, VOID.TRIPLES, rdf.createLiteral(connection.size(config.getSPARQLEndpoint()) + 2), config.getSPARQLEndpoint()));
         connection.add(dn, VOID.TRIPLES, SimpleValueFactory.getInstance().createLiteral(connection.size() + 1), config.getSPARQLEndpoint());
         connection.commit();
 
@@ -238,7 +238,7 @@ public class DatabaseBuilder extends ConfigurableBuilder {
     @Override
     public Exception handleFinishedResource(final RDFPUBResource resource) {
         // Generate static resource RDF from database
-        if (resource.hasData()) {
+        if (resource.hasData() && !resource.equals(config.getSPARQLEndpoint())) {
             // Initialize local variables
             final ValueFactory rdf = SimpleValueFactory.getInstance();
 

--- a/init/src/main/resources/lang.nginx.conf
+++ b/init/src/main/resources/lang.nginx.conf
@@ -3,6 +3,9 @@ limit_except GET OPTIONS {
   deny all;
 }
 
+# Issue relative redirects
+absolute_redirect off;
+
 # Set language cookie, cache duration, then serve redirect
 add_header Set-Cookie "lang=$lang";
 add_header Cache-Control "max-age=2592000";

--- a/render/README.md
+++ b/render/README.md
@@ -4,7 +4,7 @@ This process renders resource HTML pages based on the [Handlebars templates](htt
 
 ```sh
 npm install
-node render.js /path/to/layouts/dir /path/to/resources/dir
+node render.js /path/to/layouts/dir /path/to/resources/dir http://example.com/base/uri
 ```
 
 The `layouts` directory and the `resources` directory illustrated in the example code are meant to have been created by the init process. Once the HTML files are rendered, an rdfpub site can be built from the parent output directory via [the site build process](../site-build).

--- a/site-build/entrypoint.sh
+++ b/site-build/entrypoint.sh
@@ -11,7 +11,7 @@ OUTPUTDIR=$BASEDIR/output
 # Generate site
 mkdir -p output
 java -jar $BASEDIR/init.jar $INPUTDIR $OUTPUTDIR
-node $BASEDIR/render.min.js $OUTPUTDIR/layouts $OUTPUTDIR/resources
+node $BASEDIR/render.min.js $OUTPUTDIR/layouts $OUTPUTDIR/resources "`yq '.BaseURI' $INPUTDIR/.rdfpub`"
 
 # Clean up unneeded layout files
 rm -rf $OUTPUTDIR/layouts


### PR DESCRIPTION
# Rendering changes
- Add `$resource` and `$language` variables to Handlebars data object
- Add `equals` and `relative` Handlebars helpers

# Server changes
- Fix incorrect number of triples in the SPARQL service description output
- Fix bug where duplicate SPARQL endpoint graphs were added to the SPARQL service description
- Issue relative redirects for `@language` redirects

# Workflow changes
- Use `gh release create <tag> --generate-notes` for new releases

# Miscellaneous
- Suppress Maven artifact download log output
- Minor comment corrections