### PR TITLE
readme: wrap text and link to live tutorial site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # rdfpub Site Generator
 
-Use the rdfpub site generator to publish your RDF data and supporting files as a static-ish website. RDF + SPARQL queries + [Handlebars](https://www.handlebarsjs.com) templates go in, rendered HTML + RDF documents + a SPARQL endpoint come out, all neatly packed into a lean Docker image that you can run anywhere you can run Docker.
+Use the rdfpub site generator to publish your RDF data and supporting files as
+a static-ish website. RDF + SPARQL queries +
+[Handlebars](https://www.handlebarsjs.com) templates go in, rendered HTML + RDF
+documents + a SPARQL endpoint come out, all neatly packed into a lean Docker
+image that you can run anywhere you can run Docker.
 
 ## Features
 
@@ -13,7 +17,10 @@ Use the rdfpub site generator to publish your RDF data and supporting files as a
 
 ## Getting started
 
-If you're totally new to rdfpub, check out [the rdfpub tutorial site](https://github.com/rdfpub/tutorial-site) to learn how to build an rdfpub site by example. If you have a site that you want to build and run, simply use a pre-built generator image like so:
+If you're totally new to rdfpub, check out
+[the rdfpub tutorial site](https://rdf.pub/tutorial) to learn how to build an
+rdfpub site by example. If you have a site that you want to build and run,
+simply use a pre-built generator image like so:
 
 ```sh
 # Generate a Docker image of your site
@@ -27,8 +34,14 @@ docker run                                     \
 docker run -p 80:8081 rdfpub/example
 ```
 
-And that's it! You can access your site locally for testing, then you can deploy your site image to any environment that supports Docker, including AWS, GCP, Heroku, or other popular hosting providers.
+And that's it! You can access your site locally for testing, then you can
+deploy your site image to any environment that supports Docker, including AWS,
+GCP, Heroku, or other popular hosting providers.
 
 ## Problems?
 
-rdfpub is a continuous work-in-progress. If you encounter an error or problem, or if you have suggestions for how rdfpub could do something better, please feel free to [file an issue](https://github.com/rdfpub/generator/issues/new) with as much detail as possible.
+rdfpub is a continuous work-in-progress. If you encounter an error or problem,
+or if you have suggestions for how rdfpub could do something better, please
+feel free to [file an issue](https://github.com/rdfpub/generator/issues/new)
+with as much detail as possible.
+


### PR DESCRIPTION
In README.md, wrap text to 80 columns and link to [the live rdfpub tutorial site](https://rdf.pub/tutorial) instead of [the tutorial site source](https://github.com/rdfpub/tutorial-site).