### PR TITLE
Use StringBuilder and remove unnecessary String.format

### DIFF
--- a/init/src/main/java/pub/rdf/Main.java
+++ b/init/src/main/java/pub/rdf/Main.java
@@ -128,7 +128,7 @@ public class Main {
                         out("Directory %s is explicitly excluded from the build",dirstr);
                         return FileVisitResult.SKIP_SUBTREE;
                     } else if (dirstr.contains("/.")) {
-                        out(String.format("Skipping dot directory %s", dir));
+                        out("Skipping dot directory %s", dir);
                         return FileVisitResult.SKIP_SUBTREE;
                     }
 
@@ -154,13 +154,13 @@ public class Main {
                         out("File %s is explicitly excluded from the build",filestr);
                         return FileVisitResult.CONTINUE;
                     } else if (filestr.contains("/.")) {
-                        out(String.format("Skipping dot file %s", file));
+                        out("Skipping dot file %s", file);
                         return FileVisitResult.CONTINUE;
                     }
 
                     // Get relative path within input directory
                     final RDFPUBResource resource = resources.peek();
-                    out(String.format("Current resource is %s",resource));
+                    out("Current resource is %s",resource);
 
                     // Builder processing
                     for(final Builder builder : builders) {

--- a/init/src/main/java/pub/rdf/builder/DatabaseBuilder.java
+++ b/init/src/main/java/pub/rdf/builder/DatabaseBuilder.java
@@ -53,6 +53,7 @@ public class DatabaseBuilder extends ConfigurableBuilder {
     private final Path dbdir;
     private RepositoryConnection connection = null;
     private final Set<Namespace> namespaces = new HashSet<>(16);
+    private final StringBuilder prefixStringBuilder = new StringBuilder(512);
 
     public DatabaseBuilder(final RDFPUBConfig config) {
         super(config);
@@ -171,12 +172,20 @@ public class DatabaseBuilder extends ConfigurableBuilder {
                     ;
 
                     // Create set of global prefixes with existing query prefixes removed
+                    prefixStringBuilder.setLength(0);
                     final String globalPrefixes = config
                         .getPrefixes()
                         .entrySet()
                         .stream()
                         .filter(prefix -> !queryPrefixes.contains(prefix.getKey()))
-                        .reduce("",(str, prefix) -> str + "PREFIX " + prefix.getKey() + ": <" + prefix.getValue() + ">\n",(a,b) -> a + b)
+                        .reduce(prefixStringBuilder,(sb, prefix) ->
+                            sb.append("PREFIX ")
+                            .append(prefix.getKey())
+                            .append(": <")
+                            .append(prefix.getValue())
+                            .append(">\n"),
+                        StringBuilder::append)
+                        .toString()
                     ;
 
                     // Prepare query with prepended with undefined prefixes

--- a/init/src/main/java/pub/rdf/builder/ResourceFileBuilder.java
+++ b/init/src/main/java/pub/rdf/builder/ResourceFileBuilder.java
@@ -37,11 +37,11 @@ public class ResourceFileBuilder extends ConfigurableBuilder {
         // Do template processing
         for(final RDFPUBResource resource : layouts) {
             if(resource.getIndexTemplates().isEmpty()) {
-                out(String.format("No index templates for %s",resource));
+                out("No index templates for %s",resource);
                 continue;
             }
 
-            out(String.format("Processing layout for %s",resource));
+            out("Processing layout for %s",resource);
             for(final ResourceFile index : resource.getIndexTemplates()) {
                 // Copy file to output location
                 Files.copy(index.getPath(),resource.getLayoutPath().resolve(index.getFileName()));
@@ -49,7 +49,7 @@ public class ResourceFileBuilder extends ConfigurableBuilder {
                 // Execute queries for this index file
                 final String language = index.getLanguage();
                 for (final Map.Entry<String, TupleQuery> query : resource.getQueries().entrySet()) {
-                    out(String.format("Executing query %s", query.getKey()));
+                    out("Executing query %s", query.getKey());
                     query.getValue().setBinding("resource", resource);
                     query.getValue().setBinding("language", SimpleValueFactory.getInstance().createLiteral(language));
                     query.getValue().evaluate(new SPARQLResultsJSONWriter(new FileOutputStream(resource.getLayoutPath().resolve(String.format("%s@%s.rq", query.getKey(),language)).toFile())));
@@ -57,7 +57,7 @@ public class ResourceFileBuilder extends ConfigurableBuilder {
             }
 
             for(final Map.Entry<String, ResourceFile> partialTemplate : resource.getPartialTemplates().entrySet()) {
-                out(String.format("Copying partial template %s",partialTemplate.getKey()));
+                out("Copying partial template %s",partialTemplate.getKey());
                 Files.copy(partialTemplate.getValue().getPath(),resource.getLayoutPath().resolve(String.format("%s.handlebars",partialTemplate.getKey())));
             }
         }
@@ -140,7 +140,7 @@ public class ResourceFileBuilder extends ConfigurableBuilder {
                 if (child.equals(resource)) {
                     break;
                 } else {
-                    out(String.format("Propagating to child %s", child));
+                    out("Propagating to child %s", child);
 
                     // Propagate queries
                     for (final Map.Entry<String, TupleQuery> query : resource.getQueries().entrySet()) {

--- a/init/src/main/java/pub/rdf/util/Program.java
+++ b/init/src/main/java/pub/rdf/util/Program.java
@@ -8,17 +8,19 @@ import java.time.Instant;
 import java.util.Date;
 
 public final class Program {
+    private final static StringBuilder dateStringBuilder = new StringBuilder(32);
     private static void printDate(final PrintStream stream) {
-        stream.print(String.format("[%s] ", Date.from(Instant.now())));
+        dateStringBuilder.setLength(0);
+        stream.print(dateStringBuilder.append('[').append(Instant.now()).append(']').append(' '));
     }
     public static void out(String message, Object... objects) {
         printDate(System.out);
-        System.out.println(String.format(message,objects));
+        System.out.printf(message + "%n",objects);
     }
 
     public static void err(String message, Object... objects) {
         printDate(System.err);
-        System.err.println(String.format(message,objects));
+        System.err.printf(message + "%n",objects);
     }
 
     public static void xerr(final String why, final Exception e) {


### PR DESCRIPTION
Remove unnecessary use of `String.format` and use `StringBuilder` in more places where string concatenation is done frequently.