### PR TITLE
Set IsolationLevels.NONE for RDF4J transactions

### DIFF
--- a/init/src/main/java/pub/rdf/builder/DatabaseBuilder.java
+++ b/init/src/main/java/pub/rdf/builder/DatabaseBuilder.java
@@ -1,5 +1,6 @@
 package pub.rdf.builder;
 
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -71,7 +72,7 @@ public class DatabaseBuilder extends ConfigurableBuilder {
         connection = database.getConnection();
 
         // Initial data
-        connection.begin();
+        connection.begin(IsolationLevels.NONE);
 
         // Define namespaces
         connection.clearNamespaces();
@@ -94,7 +95,7 @@ public class DatabaseBuilder extends ConfigurableBuilder {
         // Finalize the SPARQL service description
         final ValueFactory rdf = SimpleValueFactory.getInstance();
         final BNode dn = rdf.createBNode();
-        connection.begin();
+        connection.begin(IsolationLevels.NONE);
 
         // Add SPARQL endpoint metadata
         final BNode rn = rdf.createBNode();
@@ -222,7 +223,7 @@ public class DatabaseBuilder extends ConfigurableBuilder {
 
             // Commit data
             try {
-                connection.begin();
+                connection.begin(IsolationLevels.NONE);
                 parser.parse(new FileInputStream(file.getPath().toFile()), resource.toString());
                 connection.commit();
                 resource.hasData(true);
@@ -245,7 +246,7 @@ public class DatabaseBuilder extends ConfigurableBuilder {
             // Add resource metadata
             final BNode rn = rdf.createBNode();
             final BNode gn = rdf.createBNode();
-            connection.begin();
+            connection.begin(IsolationLevels.NONE);
             connection.add(rdf.createStatement(DATASET, SD.NAMEDGRAPH, rn, config.getSPARQLEndpoint()));
             connection.add(rdf.createStatement(rn, RDF.TYPE, SD.NAMEDGRAPHCLASS, config.getSPARQLEndpoint()));
             connection.add(rdf.createStatement(rn, SD.NAME, resource, config.getSPARQLEndpoint()));


### PR DESCRIPTION
Because RDF4J is only accessed by a single thread during the build process, transaction isolation isn't needed. This change sets `IsolationLevels.NONE` so that transactions are as fast as possible.