### PR TITLE
#21: Add support for Markdown as a template language

### DIFF
--- a/init/src/main/java/pub/rdf/builder/ResourceFileBuilder.java
+++ b/init/src/main/java/pub/rdf/builder/ResourceFileBuilder.java
@@ -57,8 +57,8 @@ public class ResourceFileBuilder extends ConfigurableBuilder {
             }
 
             for(final Map.Entry<String, ResourceFile> partialTemplate : resource.getPartialTemplates().entrySet()) {
-                out(String.format("Copying partial template %s",partialTemplate.getKey()));
-                Files.copy(partialTemplate.getValue().getPath(),resource.getLayoutPath().resolve(String.format("%s.handlebars",partialTemplate.getKey())));
+                out("Copying partial template %s",partialTemplate.getKey());
+                Files.copy(partialTemplate.getValue().getPath(),resource.getLayoutPath().resolve(partialTemplate.getKey() + ".html"));
             }
         }
     }
@@ -108,8 +108,8 @@ public class ResourceFileBuilder extends ConfigurableBuilder {
             case "sparql":
                 // reserved for other builders
                 return null;
-            case "handlebars":
-            case "hbs":
+            case "html":
+            case "md":
                 if(file.isIndexTemplate()) {
                     if(file.getLanguage() == null) {
                         file.setLanguage(config.getDefaultLanguage());

--- a/init/src/main/java/pub/rdf/resource/ResourceFile.java
+++ b/init/src/main/java/pub/rdf/resource/ResourceFile.java
@@ -57,7 +57,7 @@ public class ResourceFile {
     }
 
     public boolean isTemplate() {
-        return "handlebars".equals(extension) || "hbs".equals(extension);
+        return "md".equals(extension) || "html".equals(extension);
     }
 
     public boolean isIndexTemplate() {

--- a/render/render.js
+++ b/render/render.js
@@ -152,10 +152,11 @@ class Resource {
           JSON.parse(file.read())
         );
         break;
-      case 'handlebars':
-      case 'hbs':
+      case 'md':
+      case 'html':
         if (file.name === 'index') {
-          this.indexes[file.language] = file.read();
+          const template = this.hbs.compile(file.read());
+          this.indexes[file.language] = file.extension === 'md' ? data => md.render(template(data)) : template;
         } else {
           this.hbs.registerPartial(file.name, file.read());
         }
@@ -174,7 +175,7 @@ class Resource {
       );
       fs.writeFileSync(
         `${this.outputdir}/index@${language}.html`,
-        this.hbs.compile(index)(this.queries[language])
+        index(this.queries[language])
       );
     });
   };


### PR DESCRIPTION
Add support for Markdown as a template language. This change will require that Handlebars templates be specified as either HTML (`.html` file extension) or Markdown (`.md` file extension). Markdown index templates are automatically rendered as HTML during the render process.